### PR TITLE
Add makefile, fix compile error, fix white square

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 *.exe
 *.out
 *.app
+/HexagonEngine
 
 SFML-2.5.1/*
 Hexagon Game Engine.layout

--- a/makefile
+++ b/makefile
@@ -1,0 +1,22 @@
+TARGET=HexagonEngine
+
+CC      = gcc
+CFLAGS  = -fPIC -g -O0 -D DEBUG -Wall -Wextra #-Werror
+LDFLAGS = -lsfml-graphics -lsfml-window -lsfml-system -lstdc++
+RM      = rm -f
+
+SOURCES = $(shell find src/ -name "*.cpp")
+OBJECTS = $(SOURCES:%.cpp=%.cpp.o)
+
+all: $(TARGET)
+
+$(TARGET): $(OBJECTS)
+	$(CC) $(LDFLAGS) $(OBJECTS) -o $@
+
+$(OBJECTS): %.cpp.o : %.cpp
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	$(RM) $(TARGET)
+	$(RM) $(OBJECTS)
+

--- a/src/HexagonEngine/Graphics/SpriteLoader.cpp
+++ b/src/HexagonEngine/Graphics/SpriteLoader.cpp
@@ -44,15 +44,21 @@ using namespace std;
 using namespace Hexagon;
 
 string SpriteLoader::ResourceLocation;
-std::vector<sf::Sprite> sprites();
+std::vector<sf::Sprite>* SpriteLoader::sprites;
 
 // Constructor for Spriteloader class
 SpriteLoader::SpriteLoader(string ResourceLocation) {
+    if (sprites == NULL) {
+        sprites = new std::vector<sf::Sprite>();
+    }
+
     InitSpriteLoader(ResourceLocation);
 }
 
 // Deconstructor for Spriteloader class
-SpriteLoader::~SpriteLoader() {}
+SpriteLoader::~SpriteLoader() {
+    delete sprites;
+}
 
 // Initialization Method
 void SpriteLoader::InitSpriteLoader(string ResourceLocation) {
@@ -94,7 +100,7 @@ sf::Texture SpriteLoader::LoadTexture(string name, int RectSizeX, int RectSizeY,
 
 bool SpriteLoader::AddSprite(sf::Sprite sprite) {
     try {
-        SpriteLoader::sprites().push_back(sprite);
+        SpriteLoader::sprites->push_back(sprite);
     } catch(exception e) {
         cout << "[ERROR]HE: SpriteLoader: An error occured whilst adding the Sprite to the sprite-vector!" << endl;
         return false;

--- a/src/HexagonEngine/Graphics/SpriteLoader.cpp
+++ b/src/HexagonEngine/Graphics/SpriteLoader.cpp
@@ -44,12 +44,12 @@ using namespace std;
 using namespace Hexagon;
 
 string SpriteLoader::ResourceLocation;
-std::vector<sf::Sprite>* SpriteLoader::sprites;
+std::vector<sf::Sprite*>* SpriteLoader::sprites;
 
 // Constructor for Spriteloader class
 SpriteLoader::SpriteLoader(string ResourceLocation) {
     if (sprites == NULL) {
-        sprites = new std::vector<sf::Sprite>();
+        sprites = new std::vector<sf::Sprite*>();
     }
 
     InitSpriteLoader(ResourceLocation);
@@ -71,41 +71,41 @@ void SpriteLoader::InitSpriteLoader(string ResourceLocation) {
 void SpriteLoader::LoadSprite(string name, int RectSizeX, int RectSizeY, int RectLocX, int RectLocY, bool SmoothTexture, bool SetRepeated) {
     cout << "HE: SpriteLoader: Loading sprite " << name << endl;
 
-    sf::Texture texture = LoadTexture(name, RectSizeX, RectSizeY, RectLocX, RectLocY); // Load Texture
+    sf::Texture* texture = LoadTexture(name, RectSizeX, RectSizeY, RectLocX, RectLocY); // Load Texture
 
-    texture.setSmooth(SmoothTexture); // Set texture smoothing
-    texture.setRepeated(SetRepeated); // Set texture repeating
+    texture->setSmooth(SmoothTexture); // Set texture smoothing
+    texture->setRepeated(SetRepeated); // Set texture repeating
 
-    sf::Sprite sprite;
-    sprite.setTexture(texture);
+    sf::Sprite* sprite = new sf::Sprite;
+    sprite->setTexture(*texture);
     AddSprite(sprite);
 }
 
 // Method for loading Textures
-sf::Texture SpriteLoader::LoadTexture(string name, int RectSizeX, int RectSizeY, int RectLocX, int RectLocY) {
-    sf::Texture texture;
+sf::Texture* SpriteLoader::LoadTexture(string name, int RectSizeX, int RectSizeY, int RectLocX, int RectLocY) {
+    sf::Texture* texture = new sf::Texture;
 
     // Load the texture
-    if(!texture.loadFromFile(GetResourceLocation()+"/"+name, sf::IntRect(RectLocX, RectLocY, RectSizeX, RectSizeY))) {
-        cout << "[ERROR]HE: SpriteLoader: Texture failed to load! (" << name << ")" << endl;
+    if(!texture->loadFromFile(GetResourceLocation()+"/"+name, sf::IntRect(RectLocX, RectLocY, RectSizeX, RectSizeY))) {
+        cerr << "[ERROR]HE: SpriteLoader: Texture failed to load! (" << name << ")" << endl;
     }
 
     // Create the Texture
-    if(!texture.create(RectSizeX, RectSizeY)) {
-        cout << "[ERROR]HE: SpriteLoader: Texture failed to create! (" << name << ")" << endl;
+    if(!texture->create(RectSizeX, RectSizeY)) {
+        cerr << "[ERROR]HE: SpriteLoader: Texture failed to create! (" << name << ")" << endl;
     }
 
     return texture;
 }
 
-bool SpriteLoader::AddSprite(sf::Sprite sprite) {
+bool SpriteLoader::AddSprite(sf::Sprite* sprite) {
     try {
         SpriteLoader::sprites->push_back(sprite);
     } catch(exception e) {
         cout << "[ERROR]HE: SpriteLoader: An error occured whilst adding the Sprite to the sprite-vector!" << endl;
         return false;
     }
-    cout << sprite.getTexture();
+    cout << sprite->getTexture();
 
     return true;
 }

--- a/src/HexagonEngine/Graphics/SpriteLoader.hpp
+++ b/src/HexagonEngine/Graphics/SpriteLoader.hpp
@@ -49,7 +49,7 @@ namespace Hexagon {
     class SpriteLoader {
         public:
             static string ResourceLocation;
-            static std::vector<sf::Sprite> *sprites; // Stores all loaded sprites. Regardless of location loaded from.
+            static std::vector<sf::Sprite*>* sprites; // Stores all loaded sprites. Regardless of location loaded from.
 
             SpriteLoader (string ResourceLocation);
             ~SpriteLoader();
@@ -60,8 +60,8 @@ namespace Hexagon {
             string GetResourceLocation();
         private:
 
-            bool AddSprite(sf::Sprite sprite); // Used to add a Sprite to the Engine instance
-            sf::Texture LoadTexture(string name, int RectSizeX, int RectSizeY, int RectLocX, int RectLocY); // Private Method, used for loading Textures from files
+            bool AddSprite(sf::Sprite* sprite); // Used to add a Sprite to the Engine instance
+            sf::Texture* LoadTexture(string name, int RectSizeX, int RectSizeY, int RectLocX, int RectLocY); // Private Method, used for loading Textures from files
     };
 }
 #endif // HEXAGON_SPRITELOADER_HPP

--- a/src/HexagonEngine/Graphics/SpriteLoader.hpp
+++ b/src/HexagonEngine/Graphics/SpriteLoader.hpp
@@ -49,7 +49,7 @@ namespace Hexagon {
     class SpriteLoader {
         public:
             static string ResourceLocation;
-            static std::vector<sf::Sprite> sprites(); // Stores all loaded sprites. Regardless of location loaded from.
+            static std::vector<sf::Sprite> *sprites; // Stores all loaded sprites. Regardless of location loaded from.
 
             SpriteLoader (string ResourceLocation);
             ~SpriteLoader();

--- a/src/HexagonEngine/HexagonEngine.cpp
+++ b/src/HexagonEngine/HexagonEngine.cpp
@@ -72,7 +72,7 @@ void Engine::Start() {
 
     spriteLoader->LoadSprite("MissingTexture.png", 16, 16, 0, 0, true, false);
 
-    sprite = SpriteLoader::sprites->back();
+    sprite = *SpriteLoader::sprites->back();
 
      // Gameloop
     while(hexWindow.isOpen()) {

--- a/src/HexagonEngine/HexagonEngine.cpp
+++ b/src/HexagonEngine/HexagonEngine.cpp
@@ -72,6 +72,8 @@ void Engine::Start() {
 
     spriteLoader->LoadSprite("MissingTexture.png", 16, 16, 0, 0, true, false);
 
+    sprite = SpriteLoader::sprites->back();
+
      // Gameloop
     while(hexWindow.isOpen()) {
         sf::Event event;


### PR DESCRIPTION
This PR:

- Adds an oldskool makefile to build the project without relying on Code::Blocks
- Fixes compilation error about `std::vector`
  - `std::vector<sf::Sprite*>* SpriteLoader::sprites` needed to be a pointer to a `std::vector<>`, and because it's declared as static it also needed to include the namespace (the `SpriteLoader::sprites` part).
- Fixed white square issue I found
  - This occurred because both `sf::Sprite` and `sf::Texture` in `class SpriteLoader` were non-pointer variables on the stack, meaning they automatically get deallocated (or garbage-collected if you will) whenever the scope ended. In this case it was at the end of `SpriteLoader::LoadSprite()` and `SpriteLoader::LoadTexture()`, respectively.
  - tl;dr the texture gets unloaded before it gets drawn, which results in SFML in a white square/texture.
  - By changing these into pointers, the data persist on the stack. They will probably need manual deallocation somewhere, but that's for another time :) 